### PR TITLE
Resolve AO-367 by removing excess space before the opeining <?php tag

### DIFF
--- a/waitlisttickets.php
+++ b/waitlisttickets.php
@@ -1,4 +1,4 @@
-  <?php
+<?php
 
   require_once 'waitlisttickets.civix.php';
   use CRM_Waitlisttickets_ExtensionUtil as E;


### PR DESCRIPTION
I discovered that when you actually inspected a downloaded image by right clicking and selecting download in the KCFinder, then opening the file in a notepad++ or similar that there were 2 spaces before the content. Removing the spaces allowed the image to work. This is currently deployed on jma staging for AO

ping @monishdeb 